### PR TITLE
Improvements

### DIFF
--- a/client/cl_cache.lua
+++ b/client/cl_cache.lua
@@ -1,78 +1,38 @@
 -- Created by Mascotte45
 
-Cache = {}
+local Cache = {}
 
--- Player/Ped Id
-
-Cache.ClientPlayerId = PlayerId()
-Cache.ClientPedId = PlayerPedId()
-Cache.PlayerFromServerId = GetPlayerFromServerId(Cache.ClientPlayerId)
-Cache.GetPlayerPed = GetPlayerPed(Cache.PlayerFromServerId)
-
-
--- Coordinates
-
-Cache.ClientGetEntityCoords = GetEntityCoords(Cache.ClientPedId) -- Get the player coords
-Cache.ClientGetEntityHeading = GetEntityHeading(Cache.ClientPedId) -- Get the player heading
-
--- Menu Stuff
-
-Cache.PauseMenuStatus = IsPauseMenuActive() -- True/False Is The pause menu open or closed?
-
--- Vehicle
-
-Cache.IsInCopCar = IsPedInAnyPoliceVehicle(Cache.ClientPedId) -- True/False Is the Player In a Police Vehicle
-Cache.IsPedOnFoot = IsPedOnFoot(Cache.PlayerPedId) -- True/False Is the player on foot or in a vehicle
-Cache.PlayersLastVehicle = GetPlayersLastVehicle() -- Last vehicle player was in
-Cache.IsPedSittingInAnyVehicle = IsPedSittingInAnyVehicle(Cache.ClientPedId) -- True/False Is the player sitting in a vehicle?
-Cache.GetVehiclePedIsCurrentlyIn = GetVehiclePedIsIn(Cache.ClientPedId, false) -- Vehicle Player is currently in 
-Cache.IsPedInAnyVehicle = IsPedInAnyVehicle(Cache.PlayerPedId, false) -- True/False is player in any kind of vehicle
-
-
-Citizen.CreateThread(function()
+CreateThread(function()
 
     while true do
-   
-        -- Player/Ped Id
-            
-        Cache.ClientPlayerId = PlayerId()
-   
-        Cache.ClientPedId = PlayerPedId()
-    
-        Cache.PlayerFromServerId = GetPlayerFromServerId(Cache.ClientPlayerId)
-   
-        Cache.GetPlayerPed = GetPlayerPed(Cache.PlayerFromServerId)
-            
-        -- Coordinates    
-    
-        Cache.ClientGetEntityCoords = GetEntityCoords(Cache.ClientPedId)
-            
-        Cache.ClientGetEntityHeading = GetEntityHeading(Cache.ClientPedId) 
-            
-        -- Menu Stuff
-            
-        Cache.PauseMenuStatus = IsPauseMenuActive()    
-            
-        -- Vehicle
-            
-        Cache.GetVehiclePedIsCurrentlyIn = GetVehiclePedIsIn(Cache.ClientPedId, false)
-    
-        Cache.IsPedInAnyVehicle = IsPedInAnyVehicle(Cache.ClientPlayerPedId, false)
 
-        Cache.IsPedOnFoot = IsPedOnFoot(Cache.PlayerPedId)
+        Cache.PlayerId = PlayerId()
 
-        Cache.IsPedSittingInAnyVehicle = IsPedSittingInAnyVehicle(Cache.ClientPedId)
+        Cache.PlayerPed = PlayerPedId()
 
-        Cache.IsInCopCar = IsPedInAnyPoliceVehicle(Cache.ClientPedId)
+        Cache.PlayerServerId = GetPlayerFromServerId(Cache.PlayerId)
+
+        Cache.PlayerCoords = GetEntityCoords(Cache.PlayerPed)
+
+        Cache.PlayerHeading = GetEntityHeading(Cache.PlayerPed)
+
+        Cache.PlayerVehicle = GetVehiclePedIsIn(Cache.PlayerPed, false)
+
+        Cache.IsPlayerInVehicle = IsPedInAnyVehicle(Cache.PlayerPed, false)
+
+        Cache.IsPlayerOnFoot = IsPedOnFoot(Cache.PlayerPedId)
+
+        --Wouldn't this return the same thing as IsPLayerInAnyVehicle?
+        --Cache.IsPedSittingInAnyVehicle = IsPedSittingInAnyVehicle(Cache.PlayerPed)
+
+        Cache.IsPlayerInCopCar = IsPedInAnyPoliceVehicle(Cache.PlayerPed)
 
         Cache.PlayersLastVehicle = GetPlayersLastVehicle()
-        
 
-        Citizen.Wait(200)
-    
+        Wait(2500)
     end
-
-
 end)
 
-
+exports('requestCache', function()
+  return Cache
+end)

--- a/client/common.lua
+++ b/client/common.lua
@@ -1,7 +1,0 @@
-AddEventHandler('mascotte-cache:getCacheData', function(cb)
-	cb(Cache)
-end)
-
-function getCacheData()
-	return Cache
-end

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,21 +1,11 @@
 fx_version 'cerulean'
-games { 'rdr3', 'gta5' }
+game 'gta5'
 
 author 'Mascotte45'
 description 'Simple resource that caches the most repetitive natives giving a huge performance boost!'
-version '1.0.0'
+version '1.0.1'
 
 -- What to run
-client_scripts { 
-	
-	'client/common.lua',
+client_scripts {
 	'client/cl_cache.lua'
-	
-	}
-    
-
-
-exports {
-	'getCacheData'
 }
-


### PR DESCRIPTION
1: Removed common.lua we now use an export with an anonymous function that returns the entire cache table.
2:  Don't propagate Cache table to global env as it isn't necessary 
3: Better way to retrieve cache values
```lua
-- This will return the player local ped
exports.cache:requestCache().PlayerPed
```
4: Removed value "Cache.GetPlayerPed" it returns the same value as PlayerPedId() but is slower
5: This resource will only work with gta5 not rdr3